### PR TITLE
Gpu swap prefetch

### DIFF
--- a/include/mxnet/gpu_swap_history.h
+++ b/include/mxnet/gpu_swap_history.h
@@ -50,7 +50,7 @@ public:
   void PrintRecord(int device);
   void StartIteration();
   void StopIteration();
-  MemRecord find(std::vector<MemRecord> v, size_t target_step);
+  MemRecord find(std::vector<MemRecord> records, size_t target_step);
 
 private:
   MemHistory();

--- a/include/mxnet/gpu_swap_history.h
+++ b/include/mxnet/gpu_swap_history.h
@@ -26,12 +26,16 @@ public:
     handle_id_t handle_id;
     record_t operation_id;
     timestamp_t time;
+    size_t record_step;
     size_t size;
   };
+  static bool CompareByStep(const MemRecord &r1, const MemRecord &r2) {
+    return r1.record_step < r2.record_step;
+  }
 
-  std::vector<std::vector<MemRecord> > history 
-      = std::vector<std::vector<MemRecord> >(NUMBER_OF_GPU);
-  std::vector<std::map<handle_id_t, std::vector<MemRecord> > > sorted_history
+  //std::vector<std::vector<MemRecord> > history 
+  //    = std::vector<std::vector<MemRecord> >(NUMBER_OF_GPU);
+  std::vector<std::map<handle_id_t, std::vector<MemRecord> > > history
       = std::vector<std::map<handle_id_t, std::vector<MemRecord> > >
       (NUMBER_OF_GPU);
   size_t record_idx;
@@ -46,6 +50,7 @@ public:
   void PrintRecord(int device);
   void StartIteration();
   void StopIteration();
+  MemRecord find(std::vector<MemRecord> v, size_t target_step);
 
 private:
   MemHistory();

--- a/include/mxnet/gpu_swap_history.h
+++ b/include/mxnet/gpu_swap_history.h
@@ -2,6 +2,7 @@
 #define GPU_SWAP_HISTORY_H_
 
 #include <chrono>
+#include <map>
 #include <vector>
 #include <thread>
 #include <mutex>
@@ -28,8 +29,11 @@ public:
     size_t size;
   };
 
-  std::vector<std::vector<MemRecord> > 
-      history = std::vector<std::vector<MemRecord> >(NUMBER_OF_GPU);
+  std::vector<std::vector<MemRecord> > history 
+      = std::vector<std::vector<MemRecord> >(NUMBER_OF_GPU);
+  std::vector<std::map<handle_id_t, std::vector<MemRecord> > > sorted_history
+      = std::vector<std::map<handle_id_t, std::vector<MemRecord> > >
+      (NUMBER_OF_GPU);
   size_t record_idx;
 
   ~MemHistory();

--- a/include/mxnet/swap.h
+++ b/include/mxnet/swap.h
@@ -9,6 +9,7 @@ namespace mxnet {
 
 using handle_id_t = unsigned long long;
 using timestamp_t = unsigned long long;
+using timestep_t = unsigned long long;
 
 struct SwapInfo {
   handle_id_t handle_id;

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -459,10 +459,10 @@ def _notify_shutdown():
 atexit.register(_notify_shutdown)
 
 def start_iteration():
-    check_call(_LTB.MXStartIteration())
+    check_call(_LIB.MXStartIteration())
 
-def end_iteration():
-    check_call(_LTB.MXStopIteration())
+def stop_iteration():
+    check_call(_LIB.MXStopIteration())
 
 def add_fileline_to_docstring(module, incursive=True):
     """Append the definition position to each function contained in module.

--- a/src/storage/gpu_swap_history.cc
+++ b/src/storage/gpu_swap_history.cc
@@ -1,4 +1,6 @@
 #include <iostream>
+#include <fstream>
+#include <algorithm>
 #include <vector>
 #include <set>
 #include <mxnet/gpu_swap_history.h>
@@ -32,46 +34,67 @@ void MemHistory::PutRecord(handle_id_t handle_id, int device,
     std::lock_guard<std::mutex> lock(mutex_[device]);
     timestamp_t t = (duration_cast<microseconds>
         (high_resolution_clock::now() - begin_time_)).count();
-    MemRecord record = {handle_id, operation_id, t, size};
-    history[device].push_back(record);
-    sorted_history[device][handle_id].push_back(record);
+    size_t record_step = record_idx;
+    MemRecord record = {handle_id, operation_id, t, record_step, size};
+    history[device][handle_id].push_back(record);
   }
   record_idx++;
 }
 
 handle_id_t MemHistory::DecideVictim(std::vector<handle_id_t> handles, int device) {
-  // TODO(karl): not implemented
-  //std::lock_guard<std::mutex> lock(mutex_[device]);
-  return 0;
+  std::lock_guard<std::mutex> lock(mutex_[device]);
+
+  size_t latest_step = 0;
+  handle_id_t latest_id = 0;
+  std::vector<handle_id_t>::iterator it;
+  for(it = handles.begin(); it != handles.end(); ++it) {
+    handle_id_t id = *it;
+    MemHistory::MemRecord r = 
+        MemHistory::find(history[device][id], record_idx);
+    if(r.record_step > latest_step) {
+      latest_step = r.record_step;
+      latest_id = r.handle_id;
+    }
+  }
+
+  return latest_id;
 }
 
 void MemHistory::PrintRecord(int device) {
   std::lock_guard<std::mutex> lock(mutex_[device]);
-  //std::vector<MemRecord>::iterator it;
-  //for(it = history[device].begin(); it != history[device].end(); ++it) {
-  //}
-  MemHistory::MemRecord r = history[device][history[device].size()-1];
-  std::cout << "Device: " << device << std::endl;
-  std::cout << "Size of history: " << history[device].size() << std::endl;
-
-  std::cout << "Latest record: ";
-  std::cout << "Handle id " << r.handle_id;
-  std::cout << ", Operation ";
-  if(r.operation_id == MemHistory::GET_ADDR)
-    std::cout << "get_addr";
-  else if(r.operation_id == MemHistory::SET_ADDR)
-    std::cout << "set_addr";
-  else
-    std::cout << "del_addr";
-  std::cout << std::endl;
-  std::cout << ", Size: " << r.size;
-  std::cout << std::endl;
+  std::ofstream f;
+  f.open("history_log.txt");
+  std::vector<MemRecord> v;
+  std::map<handle_id_t, std::vector<MemRecord> >::iterator it;
+  for(it = history[device].begin(); it != history[device].end(); ++it) {
+    for(size_t i = 0; i < (it->second).size(); i++) {
+      v.push_back(it->second[i]);
+    }
+  }
+  std::sort(v.begin(), v.end(), MemHistory::CompareByStep);
+  for(size_t i = 0; i < v.size(); i++) {
+    MemRecord r = v[i];
+    f << "No." << i << std::endl;
+    f << "Step: " << r.record_step << std::endl;
+    f << "Handle ID: " << r.handle_id << std::endl;
+    f << "Operation: ";
+    if(r.operation_id == GET_ADDR)
+      f << "get";
+    else if(r.operation_id == SET_ADDR)
+      f << "set";
+    else
+      f << "del";
+    f << std::endl;
+    f << "Time: " << r.time << std::endl;
+    f << "Size: " << r.size << std::endl;
+    f << std::endl;
+  }
 }
 
 void MemHistory::StartIteration() {
   iteration_started_ = true;
   record_idx = 0;
-  if(iteration_idx_ == 1)
+  if(iteration_idx_ == 0)
     is_recording_ = true;
   begin_time_ = high_resolution_clock::now();
 }
@@ -82,5 +105,33 @@ void MemHistory::StopIteration() {
   ++iteration_idx_;
 }
 
+MemHistory::MemRecord MemHistory::find(std::vector<MemHistory::MemRecord> v,
+    size_t step) {
+  size_t i = 0;
+  size_t j = v.size() - 1;
+  while(i < j) {
+    if(i == v.size()-1)
+      return v[i];
+    if(j == 0)
+      return v[j];
+    size_t mid = (i + j) / 2;
+    size_t c_step = v[mid].record_step;
+    bool right_before = c_step < step && v[mid+1].record_step > step;
+    if(c_step == step || right_before) {
+      return v[mid+1];
+    } else if(c_step < step) {
+      i = mid + 1;
+    } else{
+      j = mid - 1;
+    }
+  }
+  // suppress warning of reaching end of non-void function
+  // but actually should not reach here
+  return v[0];
+}
+
+
 } // namespace mxnet
+
+
 

--- a/src/storage/gpu_swap_history.cc
+++ b/src/storage/gpu_swap_history.cc
@@ -34,6 +34,7 @@ void MemHistory::PutRecord(handle_id_t handle_id, int device,
         (high_resolution_clock::now() - begin_time_)).count();
     MemRecord record = {handle_id, operation_id, t, size};
     history[device].push_back(record);
+    sorted_history[device][handle_id].push_back(record);
   }
   record_idx++;
 }


### PR DESCRIPTION
#Change#
1. Reconstruct history structure.
2. Implement naive swap victim choosing.
4. Rewrite print function for history. It now prints complete history to "history_log.txt".
3. Fix bugs associated with start iteration.