### PR TITLE
Gpu swap unlock

### DIFF
--- a/benchmark_tests/run.py
+++ b/benchmark_tests/run.py
@@ -20,7 +20,7 @@ def run_script(args):
                         args.model, args.num_layers, args.batch_size,
                         args.wide_scale, envs['MXNET_SWAP_ALGORITHM'],
                         envs['MXNET_PREFETCH_ALGORITHM'],
-                        envs['MXNET_PREFETCH_STEPS'])
+                        envs['MXNET_PREFETCH_STEP_AHEAD'])
         options = ['--num_gpus={}'.format(args.num_gpus),
                    '--num_loops={}'.format(args.num_loops),
                    '--num_layers={}'.format(args.num_layers),
@@ -114,14 +114,15 @@ def main():
     # NOTE that if b new environment variable is added, it should also be here.
     parser.add_argument('--envs', type=str, nargs='+',
                         help='Environment variables.',
-                        default=['PYTHONPATH=/home/fegin ',
-                                 'LD_LIBRARY_PATH=/usr/local/cuda/lib64 ',
-                                 'CUDA_VISIBLE_DEVICES=0 ',
-                                 'MXNET_ENGINE_TYPE=NaiveEngine ',
-                                 'MXNET_PREFETCH_ALGORITHM=ComputePrefetch ',
-                                 'MXNET_PREFETCH_STEP_AHEAD=30 ',
-                                 'MXNET_MEM_MGR_TYPE=CUDA ',
-                                 'MXNET_SWAP_ALGORITHM=NaiveHistory ',
+                        default=['PYTHONPATH=/home/fegin',
+                                 'LD_LIBRARY_PATH=/usr/local/cuda/lib64',
+                                 'CUDA_VISIBLE_DEVICES=0',
+                                 'MXNET_ENGINE_TYPE=NaiveEngine',
+                                 'MXNET_PREFETCH_ALGORITHM=ComputePrefetch',
+                                 'MXNET_PREFETCH_STEP_AHEAD=30',
+                                 'MXNET_MEM_MGR_TYPE=CUDA',
+                                 'MXNET_SWAP_ALGORITHM=NaiveHistory',
+                                 'MXNET_SWAP_ASYNC=1',
                        ])
     args, _ = parser.parse_known_args()
     print('Arguments: ')

--- a/include/mxnet/gpu_swap.h
+++ b/include/mxnet/gpu_swap.h
@@ -55,9 +55,9 @@ private:
   std::shared_ptr<MemoryManager> memory_manager_;
   pthread_rwlock_t swap_lock_;
   pthread_rwlock_t locks_[NUMBER_OF_GPU];
-  cudaStream_t streams_[NUMBER_OF_GPU];
-  bool streams_init_[NUMBER_OF_GPU];
   bool swap_locked_;
+  bool swap_async_;
+  cudaStream_t streams_[NUMBER_OF_GPU];
 }; // Class Swap
 
 } // namespace mxnet

--- a/include/mxnet/gpu_swap.h
+++ b/include/mxnet/gpu_swap.h
@@ -1,12 +1,14 @@
 #ifndef MXNET_STORAGE_SWAP_H_
 #define MXNET_STORAGE_SWAP_H_
 
-#include <pthread.h>
-#include <unordered_map>
+#include <atomic>
 #include <map>
 #include <memory>
+#include <pthread.h>
 #include <stack>
 #include <string>
+#include <unistd.h>
+#include <unordered_map>
 #include <mxnet/gpu_swap_history.h>
 #include <mxnet/gpu_swap_memmgr.h>
 #if MXNET_USE_CUDA
@@ -23,6 +25,7 @@ struct SwapInfo {
   char* cpu_address;
   size_t size;
   size_t swap_count;
+  std::atomic_flag is_swapping;
 };
 
 class Swap {
@@ -30,9 +33,9 @@ public:
   ~Swap();
   static Swap* Get();
   static std::shared_ptr<Swap> _GetSharedRef();
-  void SwapOut(unsigned required_memory, int device_id);
-  void SwapOutLocked(unsigned required_memory, int device_id);
-  void SwapIn(SwapInfo *info);
+  void SwapOut(unsigned required_memory, int device_id, bool async);
+  void SwapOutLocked(unsigned required_memory, int device_id, bool async);
+  void SwapIn(SwapInfo *info, bool async);
   void SetAddr(handle_id_t handle_id, void* dptr, size_t size, int device_id);
   void DelAddr(handle_id_t handle_id);
   void FreeAddr(handle_id_t handle_id);
@@ -52,6 +55,8 @@ private:
   std::shared_ptr<MemoryManager> memory_manager_;
   pthread_rwlock_t swap_lock_;
   pthread_rwlock_t locks_[NUMBER_OF_GPU];
+  cudaStream_t streams_[NUMBER_OF_GPU];
+  bool streams_init_[NUMBER_OF_GPU];
   bool swap_locked_;
 }; // Class Swap
 

--- a/src/storage/gpu_swap_memmgr.cc
+++ b/src/storage/gpu_swap_memmgr.cc
@@ -77,6 +77,9 @@ bool CudaMemoryManager::TryAllocate(int device_id, size_t size) {
   size_t free, total;
   CUDA_CALL(cudaMemGetInfo(&free, &total));
   // TODO(fegin): This fixed threshold is not acceptable.
+  // FIXME(fegin): The maximum threshould I used in the old MXNet is 512 MB.
+  //               We should figure out why such a large threshold is needed
+  //               for current implementation.
   return free > size + 1500000000;
 }
 

--- a/src/storage/gpu_swap_memmgr.cc
+++ b/src/storage/gpu_swap_memmgr.cc
@@ -77,7 +77,7 @@ bool CudaMemoryManager::TryAllocate(int device_id, size_t size) {
   size_t free, total;
   CUDA_CALL(cudaMemGetInfo(&free, &total));
   // TODO(fegin): This fixed threshold is not acceptable.
-  return free > size + 1000000000;
+  return free > size + 1500000000;
 }
 
 BuddyMemoryManager::BuddyMemoryManager() {

--- a/src/storage/pooled_storage_manager.h
+++ b/src/storage/pooled_storage_manager.h
@@ -111,7 +111,7 @@ void GPUPooledStorageManager::Alloc(Storage::Handle* handle) {
       do_reuse_ = false;
       ReleaseAll();
     }
-    swap_->SwapOutLocked(size, device_id_);
+    swap_->SwapOutLocked(size, device_id_, false);
     void* ret = nullptr;
     cudaError_t e = memory_manager_->Malloc(ret, size, device_id_);
     if (e != cudaSuccess && e != cudaErrorCudartUnloading) {


### PR DESCRIPTION
Unlock during swapout and swapin. Use asynchronous call for memcpy. 
Slightly increase memory usage, but make modest improvement to threadedEngine. ThreadedEngine can now match up with NaiveEngine occasionally. 
After #32 is merged I will merge from gpu_swap branch so the diff page will be less messy